### PR TITLE
test: Fix testsuite

### DIFF
--- a/jinquantities.cabal
+++ b/jinquantities.cabal
@@ -69,6 +69,7 @@ test-suite doctest
     hs-source-dirs:   test-suite
     main-is:          DocTest.hs
     type:             exitcode-stdio-1.0
+    build-tool-depends: doctest:doctest
 
 test-suite coverage
     build-depends:    base, process, regex-compat

--- a/library/Data/Quantities/ExprParser.hs
+++ b/library/Data/Quantities/ExprParser.hs
@@ -4,14 +4,15 @@
 -- and units.
 module Data.Quantities.ExprParser  where
 
-import Control.Applicative ((<*>), (<$>), (*>), (<*))
-import Data.Either (partitionEithers)
-import qualified Data.Map as M
-import Numeric (readFloat)
-import Text.ParserCombinators.Parsec
+import           Control.Applicative           ((*>), (<$>), (<*), (<*>))
+import           Data.Either                   (partitionEithers)
+import qualified Data.Map                      as M
+import           Numeric                       (readFloat)
+import           Text.ParserCombinators.Parsec
 
-import Data.Quantities.Convert (addQuants, subtractQuants, convert)
-import Data.Quantities.Data
+import           Data.Quantities.Convert       (addQuants, convert,
+                                                subtractQuants)
+import           Data.Quantities.Data
 
 -- | Alternate definition for spaces. Just actual spaces.
 spaces' :: Parser String
@@ -116,9 +117,7 @@ parseESymbolNum d = try (parseENum d) <|> parseESymbol d
 
 -- | Parses a symbol and then parses a prefix form that symbol.
 parseESymbol :: Definitions -> Parser EQuant
-parseESymbol d = do
-  q <- parseSymbol'
-  return $ preprocessQuantity d q
+parseESymbol d = preprocessQuantity d <$> parseSymbol'
 
 -- | Parse a number and insert the given definitions into the CompoundUnit.
 parseENum :: Definitions -> Parser EQuant
@@ -148,7 +147,7 @@ prefixParser :: Definitions -> String -> (String, String)
 prefixParser d input = if input `elem` unitsList d
                           then ("", input)
                           else case parse (prefixParser' d) "arithmetic" input of
-                            Left _ -> ("", input)
+                            Left _    -> ("", input)
                             Right val -> splitAt (length val) input
 
 -- | Helper function for prefixParser that is a Parsec parser.

--- a/test-suite/DocCoverage.hs
+++ b/test-suite/DocCoverage.hs
@@ -1,10 +1,10 @@
 module Main (main) where
 
-import Data.List (genericLength)
-import Data.Maybe (catMaybes)
-import System.Exit (exitFailure, exitSuccess)
-import System.Process (readProcess)
-import Text.Regex (matchRegex, mkRegex)
+import           Data.List      (genericLength)
+import           Data.Maybe     (mapMaybe)
+import           System.Exit    (exitFailure, exitSuccess)
+import           System.Process (readProcess)
+import           Text.Regex     (matchRegex, mkRegex)
 
 average :: (Fractional a, Real b) => [b] -> a
 average xs = realToFrac (sum xs) / genericLength xs
@@ -20,6 +20,6 @@ main = do
         else putStr output >> exitFailure
 
 match :: String -> [Int]
-match = fmap read . concat . catMaybes . fmap (matchRegex pattern) . lines
+match = fmap read . concat . mapMaybe (matchRegex pat) . lines
   where
-    pattern = mkRegex "^ *([0-9]*)% "
+    pat = mkRegex "^ *([0-9]*)% "


### PR DESCRIPTION
- Prevent hlint from having a parse error on `DocCoverage.hs`
- Add `doctest:doctest` as a build tool for the doctest test

This doesn't fix the testsuite in Nix however because it calls the `cabal` executable in a rather dirty way which can't be automatically converted to Nix, but it can be patched on the Nix side