### PR TITLE
fix the doctest suite

### DIFF
--- a/library/Data/Quantities.hs
+++ b/library/Data/Quantities.hs
@@ -124,4 +124,4 @@ import Data.Quantities.DefaultUnits (defaultDefString)
 -- >>> let (Right m)  = fromString "m"
 -- >>> let (Right ft) = myFromString "ft"
 -- >>> convert m (units ft)
--- Left (DifferentDefinitionsError meter foot)
+-- Left The units meter and footcome from different definitions and can't be used together

--- a/library/Data/Quantities/Constructors.hs
+++ b/library/Data/Quantities/Constructors.hs
@@ -19,7 +19,7 @@ defaultDefinitions = readDefinitions defaultDefString
 -- >>> fromString "25 m/s"
 -- Right 25.0 meter / second
 -- >>> fromString "fakeunit"
--- Left (UndefinedUnitError "fakeunit")
+-- Left Undefined unit fakeunit
 -- >>> fromString "ft + 12in"
 -- Right 2.0 foot
 --
@@ -32,14 +32,14 @@ defaultDefinitions = readDefinitions defaultDefString
 -- >>> fromString "2 ft + 6 in => ft"
 -- Right 2.5 foot
 -- >>> fromString "m => 3 ft"
--- Left (ScalingFactorError 3.0 foot)
+-- Left Unexpected scaling factor 3.0 foot
 --
 -- Make sure not to use dimensional quantities in exponents.
 --
 -- >>> fromString "m ** 2"
 -- Right 1.0 meter ** 2
 -- >>> fromString "m ** (2s)"
--- Left (ParserError "Used non-dimensionless exponent in ( Right 1.0 meter ) ** ( Right 2.0 second )")
+-- Left Parse error: Used non-dimensionless exponent in ( Right 1.0 meter ) ** ( Right 2.0 second )
 fromString :: String -> Either (QuantityError Double) (Quantity Double)
 fromString s = case defaultDefinitions of
                     (Right d) -> parseExprQuant d s

--- a/library/Data/Quantities/Data.hs
+++ b/library/Data/Quantities/Data.hs
@@ -123,8 +123,8 @@ instance Show a => Show (QuantityError a) where
   show e = case e of
     UndefinedUnitError unit -> "Undefined unit " ++ unit
     DimensionalityError u1 u2 ->
-      "Trying to convert between " ++ show u1 ++ " and " ++ show u2 ++
-        " which are of different dimensions"
+      "Trying to convert between [" ++ show u1 ++ "[ and [" ++ show u2 ++
+        "] which are of different dimensions"
     UnitAlreadyDefinedError unit -> "Unit already defined " ++ unit
     PrefixAlreadyDefinedError pfx ->
       "Prefix alredy defined " ++ pfx

--- a/library/Data/Quantities/Data.hs
+++ b/library/Data/Quantities/Data.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 
 -- | Base module for all data structures.
 module Data.Quantities.Data where


### PR DESCRIPTION
We've noticed that, when inferring the unit of a formula, the resulting unit is not really human-readable due to the fact that it has not been simplified.  
For instance, the unit inferred from a formula is displayed as:
```
milliliter millimole *2 / liter *2 / minute / micromole
```
This unit is correct, but could be simplified to:
```
mmol/L/min
```
which is much more readable.