### PR TITLE
fix: Add hspec to the build-tools

### DIFF
--- a/jinquantities.cabal
+++ b/jinquantities.cabal
@@ -56,6 +56,7 @@ test-suite hspec
     main-is:          Spec.hs
     type:             exitcode-stdio-1.0
     build-depends:    base >=4 && < 5, jinquantities, hspec, containers, mtl, parsec
+    build-tool-depends: hspec-discover:hspec-discover
 
 test-suite hlint
     build-depends:    base, hlint


### PR DESCRIPTION
Otherwise `cabal new-test` can't find it and the test fails.

Note that the testsuite still fails because #3 broke doctest